### PR TITLE
Undeprecate `mergeSignals`, use `AbortSignal.any()` inside

### DIFF
--- a/source/merge-signals.md
+++ b/source/merge-signals.md
@@ -1,12 +1,6 @@
-> [!NOTE]
-> This utility is available natively as [`AbortSignal.any()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static). Chrome has supported it since August 2023, Node since June 2023 and Safari/Firefox since March 2024. Prefer using the native method if you don't need to support older browsers.
-
 # mergeSignals(...signals)
 
-Returns an `AbortSignal` that aborts when any of the input is aborted. Ideal when:
-
-- you want to **add** a timeout signal
-- you receive a `signal` and want to have your own internal abort controller.
+Like `AbortSignals.any()`, except it accepts `AbortController` and `undefined`, making it easier to use with optional signals. It requires `AbortSignals.any()` to be available in your browser/platform.
 
 ```ts
 import {mergeSignals} from 'abort-utils';
@@ -21,7 +15,7 @@ cancelButton.addEventListener('click', () => {
 const timeout = AbortSignal.timeout(100);
 
 // Merged signal
-const mergedSignal = mergeSignals(timeout, userAction.signal);
+const mergedSignal = mergeSignals(timeout, userAction);
 mergedSignal.addEventListener('abort', () => {
 	console.log('One of the signals was aborted', mergedSignal.reason);
 });
@@ -29,7 +23,7 @@ mergedSignal.addEventListener('abort', () => {
 
 ## signals
 
-Type: `AbortSignal`, `AbortController`
+Type: `AbortSignal`, `AbortController`, `undefined`
 
 The signals to listen to. If you pass a controller, it will automatically extract its signal.
 

--- a/source/merge-signals.ts
+++ b/source/merge-signals.ts
@@ -7,5 +7,11 @@ export function mergeSignals(...signals: Array<AbortSignal | {signal: AbortSigna
 				? signal
 				// @ts-expect-error idk what you're talking about, signal is not undefined
 				: signal.signal);
+
+	if (adjusted.length === 1) {
+		// Return as is
+		return adjusted[0]!;
+	}
+
 	return AbortSignal.any(adjusted);
 }

--- a/source/merge-signals.ts
+++ b/source/merge-signals.ts
@@ -1,20 +1,11 @@
-/** @deprecated Use AbortSignal.any() instead */
-export function mergeSignals(
-	...signals: Array<AbortSignal | AbortController | undefined>
-): AbortSignal {
-	const controller = new AbortController();
-	for (const abort of signals) {
-		const signal = abort instanceof AbortController ? abort.signal : abort;
-
-		if (signal?.aborted) {
-			controller.abort(signal.reason);
-			return controller.signal;
-		}
-
-		signal?.addEventListener('abort', () => {
-			controller.abort(signal.reason);
-		}, {once: true});
-	}
-
-	return controller.signal;
+/** Like AbortSignal.any(), except it accepts `undefined` as well, so you can pass in optional signals without further logic */
+export function mergeSignals(...signals: Array<AbortSignal | {signal: AbortSignal} | undefined>): AbortSignal {
+	const adjusted = signals
+		.filter(Boolean)
+		.map(signal =>
+			signal instanceof AbortSignal
+				? signal
+				// @ts-expect-error idk what you're talking about, signal is not undefined
+				: signal.signal);
+	return AbortSignal.any(adjusted);
 }


### PR DESCRIPTION



`mergeSignals` was here before `AbortSignal.any`, so now that we have the latter we don't need to recreate the logic (i.e. "polyfill" it).

I initially deprecated this method but it turns out it's still preferable to `AbortSignal.any()` when dealing with optional signals:


```diff
  function do({signal}: {signal?: AbortSignal} = {}) {
-   const timeout = AbortSignal.timeout(1000)
-   signal = signal ? Abort.any([signal, timeout]) : timeout
+   signal = mergeSignals(signal, AbortSignal.timeout(1000))
  }
```

Since it just wraps `AbortSignal.any`, this should fix https://github.com/fregante/abort-utils/issues/19, assuming that Chrome's own native implementation isn't affected.
