### PR TITLE
`promiseRaceWithSignal` - Fix leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"xo": "^1.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"

--- a/source/promise-race-with-signal.ts
+++ b/source/promise-race-with-signal.ts
@@ -8,21 +8,32 @@
  * @param signal The signal to listen to. If you pass a controller, it will automatically extract its signal.
  * @param options.abortRejects If `false`, the promise will resolve instead of reject when the signal is aborted.
  */
-export async function promiseRaceWithSignal<T, AbortRejects extends boolean = true, ReturnValue = AbortRejects extends false ? T | unknown : T>(
+async function promiseRaceWithSignal<T>(
 	promise: Promise<T>,
 	signal: AbortSignal | AbortController | undefined,
-	{abortRejects = true as AbortRejects}: {abortRejects?: AbortRejects} = {},
-): Promise<ReturnValue> {
+	options: {abortRejects?: false}
+): Promise<T | unknown>;
+
+async function promiseRaceWithSignal<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | AbortController | undefined,
+	options?: {abortRejects: true}
+): Promise<T>;
+
+async function promiseRaceWithSignal<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | AbortController | undefined,
+	{abortRejects = true}: {abortRejects?: boolean} = {},
+): Promise<T | unknown> {
 	if (!signal) {
-		return promise as ReturnValue;
+		return promise;
 	}
 
 	const trueSignal = signal instanceof AbortController ? signal.signal : signal;
-
 	if (abortRejects) {
 		trueSignal.throwIfAborted();
 	} else if (trueSignal.aborted) {
-		return trueSignal.reason as ReturnValue;
+		return trueSignal.reason;
 	}
 
 	return new Promise((resolve, reject) => {
@@ -36,8 +47,9 @@ export async function promiseRaceWithSignal<T, AbortRejects extends boolean = tr
 
 		trueSignal.addEventListener('abort', handleAbort, {once: true});
 		promise.then(resolve, reject).finally(() => {
-			// Remove listener even if the promise is fulfilled first
 			trueSignal.removeEventListener('abort', handleAbort);
 		});
-	}) as ReturnValue;
+	});
 }
+
+export {promiseRaceWithSignal};

--- a/source/promise-race-with-signal.ts
+++ b/source/promise-race-with-signal.ts
@@ -1,4 +1,4 @@
-import {promiseFromSignal} from './promise-from-signal.js';
+/* eslint-disable @typescript-eslint/prefer-promise-reject-errors, promise/prefer-catch, promise/prefer-await-to-then */
 
 /**
  * Like `Promise.race()`, but it accepts `AbortSignal` or `AbortController` instances.
@@ -8,19 +8,36 @@ import {promiseFromSignal} from './promise-from-signal.js';
  * @param signal The signal to listen to. If you pass a controller, it will automatically extract its signal.
  * @param options.abortRejects If `false`, the promise will resolve instead of reject when the signal is aborted.
  */
-async function promiseRaceWithSignal<T, AbortRejects extends boolean = true>(
+export async function promiseRaceWithSignal<T, AbortRejects extends boolean = true, ReturnValue = AbortRejects extends false ? T | unknown : T>(
 	promise: Promise<T>,
 	signal: AbortSignal | AbortController | undefined,
 	{abortRejects = true as AbortRejects}: {abortRejects?: AbortRejects} = {},
-): Promise<AbortRejects extends false ? T | unknown : T> {
+): Promise<ReturnValue> {
 	if (!signal) {
-		return promise;
+		return promise as ReturnValue;
 	}
 
-	return Promise.race([
-		promise,
-		promiseFromSignal(signal, {rejects: abortRejects}),
-	]) as Promise<AbortRejects extends false ? T | unknown : T>;
-}
+	const trueSignal = signal instanceof AbortController ? signal.signal : signal;
 
-export {promiseRaceWithSignal};
+	if (abortRejects) {
+		trueSignal.throwIfAborted();
+	} else if (trueSignal.aborted) {
+		return trueSignal.reason as ReturnValue;
+	}
+
+	return new Promise((resolve, reject) => {
+		const handleAbort = () => {
+			if (abortRejects) {
+				reject(trueSignal.reason);
+			} else {
+				resolve(trueSignal.reason);
+			}
+		};
+
+		trueSignal.addEventListener('abort', handleAbort, {once: true});
+		promise.then(resolve, reject).finally(() => {
+			// Remove listener even if the promise is fulfilled first
+			trueSignal.removeEventListener('abort', handleAbort);
+		});
+	}) as ReturnValue;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"rootDir": "./source",
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"lib": ["ES2024", "DOM"]
 	},
-	"include": [
-		"source",
-	]
+	"include": ["source"]
 }


### PR DESCRIPTION
- Should fix #17 

The implementation is slightly longer than `wrapAbort` because it has an extra option (`rejectOnAbort: false`) and it accepts `AbortController` 


cc @twschiller