### PR TITLE
`onAbort` - Add support for `Symbol.dispose`

### DIFF
--- a/source/on-abort.md
+++ b/source/on-abort.md
@@ -23,6 +23,11 @@ onAbort(signal, newController);
 
 // It can do all of that at once
 onAbort(signal, console.log, observer, newController);
+
+// Since v3.0.0 it returns a disposable object to avoid memory leaks
+// https://www.totaltypescript.com/typescript-5-2-new-keyword-using
+// Similar to node's method https://nodejs.org/api/events.html#eventsaddabortlistenersignal-listener
+using _ = onAbort(signal, console.log, observer, newController);
 ```
 
 ## signal

--- a/source/on-abort.test-d.ts
+++ b/source/on-abort.test-d.ts
@@ -11,3 +11,4 @@ onAbort(AbortSignal.abort(), new IntersectionObserver(console.log));
 onAbort(AbortSignal.abort(), () => {
 	// All good
 });
+using _: {[Symbol.dispose](): void} | undefined = onAbort(AbortSignal.abort());

--- a/source/on-abort.test.ts
+++ b/source/on-abort.test.ts
@@ -114,3 +114,31 @@ test('it passes reason to abort/abortAndReset methods but not to functions or di
 	expect(abortHandle.abort).toHaveBeenCalledWith(reason);
 	expect(abortAndResetHandle.abortAndReset).toHaveBeenCalledWith(reason);
 });
+
+test('using: it should not call handlers before or after disposal', () => {
+	const controller = new AbortController();
+	const callback1 = vi.fn();
+	const callback2 = {disconnect: vi.fn()};
+
+	{
+		using _ = onAbort(controller.signal, callback1, callback2);
+		expect(callback1).not.toHaveBeenCalled();
+		expect(callback2.disconnect).not.toHaveBeenCalled();
+	}
+
+	expect(callback1).not.toHaveBeenCalled();
+	expect(callback2.disconnect).not.toHaveBeenCalled();
+	controller.abort();
+	expect(callback1).not.toHaveBeenCalled();
+	expect(callback2.disconnect).not.toHaveBeenCalled();
+});
+
+test('using: it works with already aborted signal', () => {
+	const signal = AbortSignal.abort();
+	const callback = vi.fn();
+
+	{
+		using _ = onAbort(signal, callback);
+		expect(callback).toHaveBeenCalledTimes(1);
+	}
+});


### PR DESCRIPTION
- Fixes #18 
- Same usage as https://nodejs.org/api/events.html#eventsaddabortlistenersignal-listener

Disposable objects can be used implicitly once the current block/scope ends ([`using`](https://www.totaltypescript.com/typescript-5-2-new-keyword-using)) or by passing them around and using them as callback:

```js
function foo(signal) {
  const observer = new Foo()
  
  const disposable = onAbort(signal, observer);

  setTimeout(() => {
    disposable[Symbol.dispose]()
  }, 10000)
}