### PR TITLE
`onAbort` - Call some callbacks with `reason`

### DIFF
--- a/source/on-abort.test.ts
+++ b/source/on-abort.test.ts
@@ -109,7 +109,7 @@ test('it passes reason to abort/abortAndReset methods but not to functions or di
 
 	controller.abort(reason);
 
-	expect(functionCallback).toHaveBeenCalledWith();
+	expect(functionCallback).toHaveBeenCalledWith(reason);
 	expect(disconnectHandle.disconnect).toHaveBeenCalledWith();
 	expect(abortHandle.abort).toHaveBeenCalledWith(reason);
 	expect(abortAndResetHandle.abortAndReset).toHaveBeenCalledWith(reason);

--- a/source/on-abort.test.ts
+++ b/source/on-abort.test.ts
@@ -95,3 +95,22 @@ test('it will run all the handlers even if one throws (passing in a controller i
 	expect(callback1).toHaveBeenCalledTimes(1);
 	expect(callback2).toHaveBeenCalledTimes(1);
 });
+
+test('it passes reason to abort/abortAndReset methods but not to functions or disconnect', () => {
+	const reason = 'test-reason';
+	const controller = new AbortController();
+
+	const functionCallback = vi.fn();
+	const disconnectHandle = {disconnect: vi.fn()};
+	const abortHandle = {abort: vi.fn()};
+	const abortAndResetHandle = {abortAndReset: vi.fn()};
+
+	onAbort(controller.signal, functionCallback, disconnectHandle, abortHandle, abortAndResetHandle);
+
+	controller.abort(reason);
+
+	expect(functionCallback).toHaveBeenCalledWith();
+	expect(disconnectHandle.disconnect).toHaveBeenCalledWith();
+	expect(abortHandle.abort).toHaveBeenCalledWith(reason);
+	expect(abortAndResetHandle.abortAndReset).toHaveBeenCalledWith(reason);
+});

--- a/source/on-abort.ts
+++ b/source/on-abort.ts
@@ -1,47 +1,49 @@
-type Handle =
-	| {disconnect: VoidFunction}
-	| {abort: VoidFunction}
-	| {abortAndReset: VoidFunction}
-	| VoidFunction;
 
-function addListeners(signal: AbortSignal, handles: Handle[]) {
-	// Add one listener per `handle` so that errors don't block other listeners
-	for (const handle of handles) {
-		const options = {once: true};
-		if ('disconnect' in handle) {
-			// Like MutationObserver
-			signal.addEventListener('abort', handle.disconnect.bind(handle), options);
-		} else if ('abort' in handle) {
-			// Like AbortController
-			signal.addEventListener('abort', handle.abort.bind(handle), options);
-		} else if ('abortAndReset' in handle) {
-			// Like ReusableAbortController
-			signal.addEventListener('abort', handle.abortAndReset.bind(handle), options);
-		} else if (typeof handle === 'function') {
-			signal.addEventListener('abort', handle, options);
-		} else {
-			throw new TypeError('Invalid AbortSignal handle type');
-		}
+type Handle =
+	| {disconnect(): void}
+	| {abort(reason: any): void}
+	| {abortAndReset(reason: any): void}
+	| (() => void);
+
+const createListener = (handle: Handle) => function (this: AbortSignal): void {
+	if (typeof handle === 'function') {
+		handle();
+	} else if ('disconnect' in handle) {
+		handle.disconnect();
+	} else if ('abort' in handle) {
+		handle.abort(this.reason);
+	} else if ('abortAndReset' in handle) {
+		handle.abortAndReset(this.reason);
+	} else {
+		throw new TypeError('Invalid AbortSignal handle type');
 	}
-}
+};
 
 export function onAbort(
-	// Accept `undefined` to replicate the common `signal?.addEventListener()` pattern
 	signal: AbortController | AbortSignal | undefined,
 	...handles: Handle[]
 ): void {
-	if (!signal) {
+	if (!signal || handles.length === 0) {
 		return;
 	}
 
-	const trueSignal = signal instanceof AbortController ? signal.signal : signal;
-	if (trueSignal.aborted) {
-		// This pattern ensures that handlers are treated the same way even if the
-		// signal is already aborted. AbortSignal.abort()/.timeout() don't work the same way
-		const controller = new AbortController();
-		addListeners(controller.signal, handles);
-		controller.abort(controller.signal.reason);
-	} else {
-		addListeners(trueSignal, handles);
+	const inputSignal = signal instanceof AbortController ? signal.signal : signal;
+
+	// This pattern ensures that handlers are treated the same way even if the
+	// signal is already aborted
+	const preAbortedHelper = new AbortController();
+	const targetSignal = inputSignal.aborted
+		? preAbortedHelper.signal
+		: inputSignal;
+
+	for (const handle of handles) {
+		// Attach one listener per handle so that failures by one handle don't affect others
+		targetSignal.addEventListener('abort', createListener(handle), {
+			once: true,
+		});
+	}
+
+	if (inputSignal.aborted) {
+		preAbortedHelper.abort(inputSignal.reason);
 	}
 }

--- a/source/on-abort.ts
+++ b/source/on-abort.ts
@@ -3,11 +3,11 @@ type Handle =
 	| {disconnect(): void}
 	| {abort(reason: any): void}
 	| {abortAndReset(reason: any): void}
-	| (() => void);
+	| ((reason: any) => void);
 
 const createListener = (handle: Handle) => function (this: AbortSignal): void {
 	if (typeof handle === 'function') {
-		handle();
+		handle(this.reason);
 	} else if ('disconnect' in handle) {
 		handle.disconnect();
 	} else if ('abort' in handle) {


### PR DESCRIPTION
Callbacks other than `disconnect` will now receive the raw `reason` rather than the `event` object. `disconnect` is called without any arguments.